### PR TITLE
docs: update README and add GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,62 @@
 # Templates and assets for [docs.sourcegraph.com](https://docs.sourcegraph.com)
 
-The templates and assets for [docs.sourcegraph.com](https://docs.sourcegraph.com). The actual documentation content lives in [sourcegraph/sourcegraph in `doc/`](https://github.com/sourcegraph/sourcegraph/tree/master/doc). The [docsite](https://github.com/sourcegraph/docsite) program is used to serve the documentation website.
+This repository houses the templates and assets for [docs.sourcegraph.com](https://docs.sourcegraph.com). The actual documentation content lives in [sourcegraph/sourcegraph in `doc/`](https://github.com/sourcegraph/sourcegraph/tree/master/doc). The [docsite](https://github.com/sourcegraph/docsite) program is used to serve the documentation website.
 
-## Usage
+> NOTE: If you want to just preview changes to documentation (not templates and assets), you can view them in your Sourcegraph local dev server at http://localhost:3080/help.
 
-### Preview local template, asset, and content changes
+## Previewing template and asset changes
 
-> If you just want to preview changes to documentation content (not templates and assets), you can also just visit http://localhost:3080/help on your local dev server.
+To preview changes to documentation content, [`templates/`](templates) and [`assets/`](assets), you need to:
 
-You can preview your local changes to:
+- Install Go 1.11+
+- Install [docsite](https://github.com/sourcegraph/docsite) are required.
+- Make the [Sourcegraph repository](a sibling) so it is a sibling of `docs.sourcegraph.com`
 
-- templates (in [`templates/`](templates))
-- assets (in [`assets/`](assets))
-- documentation content (in [`../sourcegraph/doc`](https://github.com/sourcegraph/sourcegraph/tree/master/doc), which is assumed to be in your local clone of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph))
+### Installing docsite
 
-Requirements:
+To install docsite, in your terminal, change into the top-level directory of this repository, then run:
 
-- Install Go 1.11
-- Install [docsite](https://github.com/sourcegraph/docsite):
-   ```shell
-   GO111MODULE=on go get -u github.com/sourcegraph/docsite/cmd/docsite
-   ```
+```shell
+GO111MODULE=on go get -u github.com/sourcegraph/docsite/cmd/docsite
+```
 
-From the top-level directory of this repository:
+If that doesn't work, try this:
 
-- To run a web server for this doc site:
-   ```shell
-   docsite serve
-   ```
-   
-   Then visit http://localhost:5080.
-- To check for common problems in the Markdown and template files:
-   ```shell
-   docsite check
-   ```
+```shell
+# blackfriday go mod workaround
+go mod edit -replace=gopkg.in/russross/blackfriday.v2@v2.0.1=github.com/russross/blackfriday/v2@v2.0.1
+GO111MODULE=on go get -u github.com/sourcegraph/docsite/cmd/docsite
+```
 
-### Run in production
+### How docsite accesses documentation content
+
+The [`docsite.json`](docsite.json) file expects documentation to be in [`../sourcegraph/doc`](https://github.com/sourcegraph/sourcegraph/tree/master/doc), which is assumed to be in your local clone of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)). It should be a sibling of the `docs.sourcegraph.com` local clone.
+
+## Running the docsite server
+
+- To run the docsite server:
+
+```shell
+docsite serve
+```
+
+Then visit http://localhost:5080.
+
+## Checking for problems (e.g. broken links)
+
+To check for common problems in the Markdown and template files, run:
+
+```shell
+docsite check
+```
+
+It's recommended to run this before pushing docs or template/assets changes and is run in as part of the Sourcegraph build CI job.
+
+## Emulating https://docs.sourcegraph.com by running in Docker
 
 > This is how https://docs.sourcegraph.com is deployed.
+
+> NOTE: Running in Docker is only suitable for production or when downloading zipped assets.
 
 To start a web server with the latest documentation content (and templates and assets from this repository's `docs.sourcegraph.com` branch), run:
 
@@ -49,7 +68,7 @@ docker run -p 5080:5080 \
 
 Then visit http://localhost:5080.
 
-### Update production templates and assets
+## Updating production templates and assets
 
 Push to this repository's `docs.sourcegraph.com` branch:
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This repository houses the templates and assets for [docs.sourcegraph.com](https
 To preview changes to documentation content, [`templates/`](templates) and [`assets/`](assets), you need to:
 
 - Install Go 1.11+
-- Install [docsite](https://github.com/sourcegraph/docsite) are required.
-- Make the [Sourcegraph repository](a sibling) so it is a sibling of `docs.sourcegraph.com`
+- Install [docsite](https://github.com/sourcegraph/docsite).
+- Enable docsite to access the Sourcegraph `/doc` directory
 
 ### Installing docsite
 
@@ -30,11 +30,11 @@ GO111MODULE=on go get -u github.com/sourcegraph/docsite/cmd/docsite
 
 ### How docsite accesses documentation content
 
-The [`docsite.json`](docsite.json) file expects documentation to be in [`../sourcegraph/doc`](https://github.com/sourcegraph/sourcegraph/tree/master/doc), which is assumed to be in your local clone of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)). It should be a sibling of the `docs.sourcegraph.com` local clone.
+The [`docsite.json`](docsite.json) file expects documentation to be in [`../sourcegraph/doc`](https://github.com/sourcegraph/sourcegraph/tree/master/doc), which is assumed to be in your local clone of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph). In other words, the `sourcegraph` local clone should be a sibling of the `docs.sourcegraph.com` local clone.
 
 ## Running the docsite server
 
-- To run the docsite server:
+To run the docsite server:
 
 ```shell
 docsite serve
@@ -44,17 +44,17 @@ Then visit http://localhost:5080.
 
 ## Checking for problems (e.g. broken links)
 
-To check for common problems in the Markdown and template files, run:
+To check for problems in the Markdown and template files, run:
 
 ```shell
 docsite check
 ```
 
-It's recommended to run this before pushing docs or template/assets changes and is run in as part of the Sourcegraph build CI job.
+It's recommended to run this before pushing docs or template/assets changes and is run as part of the Sourcegraph build job.
 
 ## Emulating https://docs.sourcegraph.com by running in Docker
 
-> This is how https://docs.sourcegraph.com is deployed.
+> NOTE: This is how https://docs.sourcegraph.com is deployed.
 
 > NOTE: Running in Docker is only suitable for production or when downloading zipped assets.
 

--- a/templates/doc.html
+++ b/templates/doc.html
@@ -61,7 +61,16 @@
 						{{end}}
 					</section>
 				</div>
-			</div>
+      </div>
+
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-20"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-40540747-20');
+      </script>
 		</body>
 	</html>
 {{end}}


### PR DESCRIPTION
Updated README.md to be clearer on what is required to view docs or template and asset changes.

Added GA to get visibility into what pages users are viewing and what search terms are being used to get them there.

> NOTE: This does **NOT** affect the rendering of `/help` content on Sourcegraph as it does not use the `doc.html` template.