### PR TITLE
Sync GA on docs

### DIFF
--- a/templates/doc.html
+++ b/templates/doc.html
@@ -61,15 +61,26 @@
 					</section>
 				</div>
       </div>
-
       <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40540747-20"></script>
       <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
+        {{/* docs.sourcegraph.com only */}}
         gtag('config', 'UA-40540747-20');
+        {{/* about.sourcegraph.com + docs.sourcegraph.com */}}
+        gtag('config', 'UA-40540747-17');
+        gtag('config', 'AW-868484203');
       </script>
+      {{if (eq .ContentPagePath "")}}
+        {{/*
+        register AdWords conversion on https://docs.sourcegraph.com (i.e., on Quickstart)
+        */}}
+        <script>
+          gtag('event', 'conversion', {'send_to': 'AW-868484203/v2YvCJ2s3JUBEOuIkJ4D'});
+        </script>
+      {{end}}
 		</body>
 	</html>
 {{end}}


### PR DESCRIPTION
This adds a 2nd GA property on our docs site, which will allow us to view traffic from about.sourcegraph.com to docs.sourcegraph.com. 

This also adds AdWord conversion tracking when users view the Quickstart, so we can track whether someone who lands on sourcegraph.com ultimately clicks a "deploy" or "install" button and lands there.